### PR TITLE
Refactor scrollToSection for improved accuracy

### DIFF
--- a/src/app/components/Navigation.tsx
+++ b/src/app/components/Navigation.tsx
@@ -32,9 +32,14 @@ const Navigation = () => {
     e.preventDefault();
     const element = document.querySelector(href);
     if (element) {
-      const offsetTop = element.getBoundingClientRect().top + window.pageYOffset - 80;
+      // Get the navigation bar height
+      const navHeight = 80; // This should match your nav height
+      // Use window.scrollY instead of pageYOffset (deprecated)
+      const elementPosition = element.getBoundingClientRect().top + window.scrollY;
+      const offsetPosition = elementPosition - navHeight;
+
       window.scrollTo({
-        top: offsetTop,
+        top: offsetPosition,
         behavior: 'smooth'
       });
     }


### PR DESCRIPTION
Replace deprecated `pageYOffset` with `window.scrollY` in the `scrollToSection` function to enhance accuracy and maintainability.