### PR TITLE
Remove deprecated react-tsparticles dependency and update dev script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,6 @@
         "react-icons": "^5.5.0",
         "react-markdown": "^10.1.0",
         "react-particles": "^2.12.2",
-        "react-tsparticles": "^2.12.2",
         "react-type-animation": "^3.2.0",
         "remark": "^15.0.1",
         "remark-html": "^16.0.1",
@@ -7847,34 +7846,6 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz",
       "integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==",
       "license": "MIT"
-    },
-    "node_modules/react-tsparticles": {
-      "version": "2.12.2",
-      "resolved": "https://registry.npmjs.org/react-tsparticles/-/react-tsparticles-2.12.2.tgz",
-      "integrity": "sha512-/nrEbyL8UROXKIMXe+f+LZN2ckvkwV2Qa+GGe/H26oEIc+wq/ybSG9REDwQiSt2OaDQGu0MwmA4BKmkL6wAWcA==",
-      "deprecated": "@tsparticles/react is the new version, please use that",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/matteobruni"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/tsparticles"
-        },
-        {
-          "type": "buymeacoffee",
-          "url": "https://www.buymeacoffee.com/matteobruni"
-        }
-      ],
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      },
-      "peerDependencies": {
-        "react": ">=16"
-      }
     },
     "node_modules/react-type-animation": {
       "version": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbopack",
+    "dev": "next dev",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"
@@ -26,7 +26,6 @@
     "react-icons": "^5.5.0",
     "react-markdown": "^10.1.0",
     "react-particles": "^2.12.2",
-    "react-tsparticles": "^2.12.2",
     "react-type-animation": "^3.2.0",
     "remark": "^15.0.1",
     "remark-html": "^16.0.1",

--- a/src/app/components/DevOpsTerminal.tsx
+++ b/src/app/components/DevOpsTerminal.tsx
@@ -81,7 +81,7 @@ const DevOpsTerminal = () => {
 
   return (
     <motion.div 
-      className="w-full h-full bg-gray-900 rounded-lg border border-gray-700 overflow-hidden shadow-xl"
+      className="w-full h-full bg-gray-900 rounded-lg border border-gray-700 overflow-hidden shadow-xl relative z-0 mt-24 sm:mt-16"
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.5 }}
@@ -110,7 +110,7 @@ const DevOpsTerminal = () => {
             ))}
           </div>
         ))}
-        {(isTyping || showOutput) && (
+        {(isTyping || showOutput) && currentCommandIndex < commands.length && (
           <div className="mb-4">
             <div className="flex items-center text-gray-300">
               <span className="text-blue-400">➜</span>


### PR DESCRIPTION
Eliminate the deprecated `react-tsparticles` dependency and adjust the development script for improved compatibility.